### PR TITLE
Update proc-rhel-installing-multiple-minor-versions.adoc

### DIFF
--- a/modules/proc-rhel-installing-multiple-minor-versions.adoc
+++ b/modules/proc-rhel-installing-multiple-minor-versions.adoc
@@ -35,3 +35,7 @@ openjdk version "1.8.0_172"
 OpenJDK Runtime Environment (build 1.8.0_172-b11)
 OpenJDK 64-Bit Server VM (build 25.172-b11, mixed mode)
 ----
+
+. Support
+
+Only the latest minor version is supported if there is a crash or other issue requiring a patch. In addition, OpenJDK is dependent on OS libraries, so only specific versions/kernels combinations are tested/supported. 


### PR DESCRIPTION
#9 Add support implications for running multiple minor versions as detailed here:
https://developers.redhat.com/blog/2018/11/05/migrating-from-oracle-jdk-to-openjdk-on-red-hat-enterprise-linux-what-you-need-to-know/